### PR TITLE
Fix `exports` in package.json (#1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   },
   "exports": {
     "require": "./dist/index.js",
-    "default": "./dist/index.modern.js"
+    "default": "./dist/index.modern.mjs",
+    "types": "./dist/index.d.ts"
   },
   "files": [
     "dist"


### PR DESCRIPTION
- Fix typo in `index.modern.mjs`
- Add typings to `exports`

Fixes #1 